### PR TITLE
fix shape mismatch error when predicting spacegroups

### DIFF
--- a/cryspnet/models.py
+++ b/cryspnet/models.py
@@ -346,8 +346,8 @@ class SpaceGroupModelBundle(BLSpliterBundle):
         # output topN probability and classes 
         # n = args["n"] if "n" in args.keys() else 1
         n = args["n"]
-        outs = np.zeros((self.data_size, n) if n > 1 else self.data_size)
-        outs_probs = np.zeros((self.data_size, n) if n > 1 else self.data_size)
+        outs = np.zeros((self.data_size, n))
+        outs_probs = np.zeros((self.data_size, n))
         for name, idx in self.idxs.items():
             prob, sg = preds[name]
             prob, sg = _pad_sg_out(prob, sg, n)


### PR DESCRIPTION
**Issue**
When generating space group predictions, there was shape mismatch between output array and space group predictions & probabilities when only top 1 space groups were generated (n=1)
```
class SpaceGroupModelBundle(BLSpliterBundle):
    def p2o(self, preds:Dict[str, torch.Tensor], **args):
      [....]
      outs_probs[idx] = prob #len(outs_probs[idx].shape) = 1 ; len(prob.shape )= 2
      outs[idx] = sg  #len(outs[idx].shape) = 1 ; len(sg.shape) = 2
      [....]
```

Error message:
```
ValueError: shape mismatch: value array of shape (X,1)  could not be broadcast to indexing result of shape (X,)
```

**Changes made**
Output arrays were being generated as 1D when n=1. Changed code to always generate 2D output arrays.
