### PR TITLE
Fix decomp bug

### DIFF
--- a/random_crystal.py
+++ b/random_crystal.py
@@ -97,9 +97,9 @@ def is_stoi(formula:str):
 
 def decomp(formula:str):
     """ parse formula into elements and stoichiometric """
-    groups = re.findall("([A-Za-z]{1,2})([0-9]+)", formula)
-    
-    elements, stois = list( zip(*groups) )
+    comp = Composition(formula)
+    comp = comp.as_dict()
+    elements, stois = list(zip(*comp.items()))
     stois = list(map(int, stois))
     return elements, stois
 


### PR DESCRIPTION
This fixes the bug in random_crystal.decomp function that occurs when passing a formula where a single letter element is not followed by a number. See example bellow.

Expected behaviour:
 Li6PS5Cl -> ['Li', 'P', 'S', Cl] [6, 1, 5, 1]

Actual behaviour:
 Li6PS5Cl ->['Li', 'PS'] [6, 5] 
