### PR TITLE
Fix cpu use for fastai2

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -39,7 +39,9 @@ def main():
     args = parser.parse_args()
 
     if args.no_cuda:
-        defaults.device = torch.device('cpu')
+        cpu = True
+    else:
+        cpu = False if torch.cuda.is_available() else True
     if args.use_metal and args.use_oxide:
         raise Exception("Could only select --use_metal or --use_oxide")
     elif args.use_metal:
@@ -49,12 +51,9 @@ def main():
     else:
         which = "whole"
 
-    BE = load_Bravais_models(
-            n_ensembler = args.n_ensembler,
-            which = which,
-            batch_size = args.batch_size)
-    LPB = load_Lattice_models(batch_size = args.batch_size)
-    SGB = load_SpaceGroup_models(batch_size = args.batch_size)
+    BE = load_Bravais_models(n_ensembler = args.n_ensembler, which = which, batch_size = args.batch_size, cpu=cpu)
+    LPB = load_Lattice_models(batch_size = args.batch_size, cpu=cpu)
+    SGB = load_SpaceGroup_models(batch_size = args.batch_size, cpu=cpu)
 
     formula = load_input(args.input)
     ext_magpie = featurizer.generate(formula)


### PR DESCRIPTION
This handles fix for the following error which occurs when trying to run CRYSPNet predict.py on machine with no cuda.

`RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False.`

Cause of the error:
'defaults.device = torch.device('cpu')' is for fastai and does not work with fastai2. 

Solution 
Use boolean variable 'cpu' to indicate if cpu should be used. Pass this as input when loading models since these can already take 'cpu' as a parameter.

Note:
This solution was not tested on a CUDA machine, i.e. the use of CUDA was not tested. 
